### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#bash script file
+*.sh  text eol=lf


### PR DESCRIPTION
added eol=lf attribute coz git core.autocrlf replaces lf to crlf once cloned under windows