### PR TITLE
Fix run.sh: Strip whitespace from package check count output

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -37,7 +37,7 @@ if [ "$SSH2_PKG" = "0" ]; then
 	# install
 	python3 -m pip install -r requirements.txt
 	# check
-	SSH2_PKG=`find ./venv -type d -wholename '*/site-packages/ssh2_python*' | wc -l`
+	SSH2_PKG=`find ./venv -type d -wholename '*/site-packages/ssh2_python*' | wc -l | tr -d ' '`
 	if [ "$SSH2_PKG" = "0" ]; then
 		echo "ERROR: XMiR: python3 package 'ssh2-python' not installed!"
 		deactivate


### PR DESCRIPTION
- Remove leading/trailing spaces from `wc -l result using tr -d ' '`
- Fixes BSD/macOS `wc` behavior showing padded whitespace in counts