### PR TITLE
Add 'backups/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 __pycache__/
 xmir_base/__pycache__/
+backups/
 data/
 tmp/
 outdir/


### PR DESCRIPTION
Add 'backups/' folder to .gitignore so your personal backup files won't appear in git while you're working on the code modifications, but you can still store your backups there without needing to move them anywhere.