### PR TITLE
Fix Language Pack persistence on Xiaomi BE3600 (RD15) and fail on real install errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 __pycache__/
 xmir_base/__pycache__/
+backups/
 data/
 tmp/
 outdir/

--- a/data/lang_install.sh
+++ b/data/lang_install.sh
@@ -13,9 +13,13 @@ TARGET2_DIR=/usr/lib/lua/luci
 MIRROR2_DIR=/tmp/_usr_lib_lua_luci
 SYNCOBJECT2=$MIRROR2_DIR.sync
 
+DATA_LANG_ROOT=/data/lang/usr/lib/lua/luci
+DATA_I18N_DIR=$DATA_LANG_ROOT/i18n
+DATA_VIEW_INC_DIR=$DATA_LANG_ROOT/view/web/inc
+
 
 if [ `find /tmp -maxdepth 1 -name 'base.*.lmo' | wc -l` -eq 0 ]; then
-	return 1
+	exit 1
 fi
 
 if [ ! -d $DIR_PATCH ]; then
@@ -65,6 +69,15 @@ fi
 mv -f /tmp/base.*.lmo $DIR_PATCH/
 mv -f /tmp/lang_patch.sh $DIR_PATCH/
 chmod +x $DIR_PATCH/lang_patch.sh
+
+mkdir -p $DATA_I18N_DIR
+cp -f $DIR_PATCH/base.*.lmo $DATA_I18N_DIR/
+
+mkdir -p $DATA_VIEW_INC_DIR
+cp -f $TARGET2_DIR/view/web/inc/sysinfo.htm $DATA_VIEW_INC_DIR/
+
+# unlock WEB lang menu in persistent copy
+sed -i 's/ and features\["system"\]\["i18n"\] == "1" //' $DATA_VIEW_INC_DIR/sysinfo.htm
 
 INSTALL_METHOD=2
 if [ ! -e "/usr/lib/os-release" ]; then
@@ -119,4 +132,5 @@ uci set luci.main.lang=en
 # forced run patch
 rm -f $INST_FLAG_FN
 $DIR_PATCH/lang_patch.sh
+exit $?
 

--- a/data/lang_patch.sh
+++ b/data/lang_patch.sh
@@ -2,7 +2,7 @@
 
 INST_FLAG_FN=/tmp/lang_patch.log
 
-[ -e "$INST_FLAG_FN" ] && return 0
+[ -e "$INST_FLAG_FN" ] && exit 0
 
 DIR_PATCH=/etc/crontabs/patches
 DIR_BACKUP=$DIR_PATCH/lang_backup
@@ -15,13 +15,30 @@ TARGET2_DIR=/usr/lib/lua/luci
 MIRROR2_DIR=/tmp/_usr_lib_lua_luci
 SYNCOBJECT2=$MIRROR2_DIR.sync
 
+TARGET2_I18N_DIR=$TARGET2_DIR/i18n
+TARGET2_SYSINFO_FN=$TARGET2_DIR/view/web/inc/sysinfo.htm
 
-if [ `find $DIR_PATCH -maxdepth 1 -name 'base.*.lmo' | wc -l` -eq 0 ]; then
-	return 0
+DATA_LANG_ROOT=/data/lang/usr/lib/lua/luci
+DATA_I18N_DIR=$DATA_LANG_ROOT/i18n
+DATA_VIEW_INC_DIR=$DATA_LANG_ROOT/view/web/inc
+DATA_SYSINFO_FN=$DATA_VIEW_INC_DIR/sysinfo.htm
+
+
+if [ `find $DIR_PATCH -maxdepth 1 -name 'base.*.lmo' | wc -l` -eq 0 ] && [ ! -d $DATA_I18N_DIR ]; then
+	exit 0
+fi
+
+for i in $(seq 1 20); do
+	mount | grep -q " on /data " && break
+	sleep 1
+done
+if ! mount | grep -q " on /data " ; then
+	echo "ERROR: /data is not mounted" > $INST_FLAG_FN
+	exit 1
 fi
 
 for i in $(seq 1 45); do
-	mkdir $SYNCOBJECT1 &> /dev/null && break
+	mkdir $SYNCOBJECT1 >/dev/null 2>&1 && break
 	sleep 1
 done
 if ! mount | grep -q " on $TARGET1_DIR" ; then
@@ -31,11 +48,13 @@ if ! mount | grep -q " on $TARGET1_DIR" ; then
 fi
 if ! mount | grep -q " on $TARGET1_DIR" ; then
 	rm -rf $SYNCOBJECT1
-	return 1  # error
+	echo "ERROR: cannot mount bind for $TARGET1_DIR" > $INST_FLAG_FN
+	exit 1
 fi
 if [ ! -f $MIRROR1_DIR/xiaoqiang_version ]; then
 	rm -rf $SYNCOBJECT1
-	return 1  # error
+	echo "ERROR: file $MIRROR1_DIR/xiaoqiang_version not found" > $INST_FLAG_FN
+	exit 1
 fi
 
 # unlock change luci.main.lang
@@ -43,31 +62,43 @@ sed -i "s/option CHANNEL 'stable'/option CHANNEL 'release'/g" $TARGET1_DIR/xiaoq
 
 rm -rf $SYNCOBJECT1
 
+mkdir -p $DATA_I18N_DIR
+cp -f $DIR_PATCH/base.*.lmo $DATA_I18N_DIR/ >/dev/null 2>&1
 
-for i in $(seq 1 45); do
-	mkdir $SYNCOBJECT2 &> /dev/null && break
-	sleep 1
-done
-if ! mount | grep -q " on $TARGET2_DIR" ; then
-	mkdir -p $MIRROR2_DIR
-	cp -rf $TARGET2_DIR/* $MIRROR2_DIR/
-	mount --bind $MIRROR2_DIR $TARGET2_DIR
-fi
-if ! mount | grep -q " on $TARGET2_DIR" ; then
-	rm -rf $SYNCOBJECT2
-	return 1  # error
-fi
-if [ ! -f $MIRROR2_DIR/i18n.lua ]; then
-	rm -rf $SYNCOBJECT2
-	return 1  # error
+if [ `find $DATA_I18N_DIR -maxdepth 1 -name 'base.*.lmo' | wc -l` -eq 0 ]; then
+	echo "ERROR: language files not found in $DATA_I18N_DIR" > $INST_FLAG_FN
+	exit 1
 fi
 
-cp -f $DIR_PATCH/base.*.lmo /usr/lib/lua/luci/i18n/
+if mount | grep -q " on $TARGET2_I18N_DIR" ; then
+	if ! mount | grep -q "$DATA_I18N_DIR on $TARGET2_I18N_DIR" ; then
+		umount -l $TARGET2_I18N_DIR
+	fi
+fi
+if ! mount | grep -q "$DATA_I18N_DIR on $TARGET2_I18N_DIR" ; then
+	mount --bind $DATA_I18N_DIR $TARGET2_I18N_DIR
+fi
+if ! mount | grep -q "$DATA_I18N_DIR on $TARGET2_I18N_DIR" ; then
+	echo "ERROR: cannot mount bind for $TARGET2_I18N_DIR" > $INST_FLAG_FN
+	exit 1
+fi
 
-# unlock WEB lang menu
-sed -i 's/ and features\["system"\]\["i18n"\] == "1" //' /usr/lib/lua/luci/view/web/inc/sysinfo.htm
+mkdir -p $DATA_VIEW_INC_DIR
+if [ ! -f $DATA_SYSINFO_FN ]; then
+	cp -f $TARGET2_SYSINFO_FN $DATA_SYSINFO_FN
+fi
 
-rm -rf $SYNCOBJECT2
+# unlock WEB lang menu in persistent copy
+sed -i 's/ and features\["system"\]\["i18n"\] == "1" //' $DATA_SYSINFO_FN
+
+if mount | grep -q " on $TARGET2_SYSINFO_FN" ; then
+	if ! mount | grep -q "$DATA_SYSINFO_FN on $TARGET2_SYSINFO_FN" ; then
+		umount -l $TARGET2_SYSINFO_FN
+	fi
+fi
+if ! mount | grep -q "$DATA_SYSINFO_FN on $TARGET2_SYSINFO_FN" ; then
+	mount --bind $DATA_SYSINFO_FN $TARGET2_SYSINFO_FN
+fi
 
 
 echo "lang patched" > $INST_FLAG_FN

--- a/data/lang_uninstall.sh
+++ b/data/lang_uninstall.sh
@@ -13,6 +13,21 @@ TARGET2_DIR=/usr/lib/lua/luci
 MIRROR2_DIR=/tmp/_usr_lib_lua_luci
 SYNCOBJECT2=$MIRROR2_DIR.sync
 
+TARGET2_I18N_DIR=$TARGET2_DIR/i18n
+TARGET2_SYSINFO_FN=$TARGET2_DIR/view/web/inc/sysinfo.htm
+
+DATA_LANG_ROOT=/data/lang/usr/lib/lua/luci
+DATA_I18N_DIR=$DATA_LANG_ROOT/i18n
+DATA_VIEW_INC_DIR=$DATA_LANG_ROOT/view/web/inc
+DATA_SYSINFO_FN=$DATA_VIEW_INC_DIR/sysinfo.htm
+
+if mount | grep -q " on $TARGET2_I18N_DIR" ; then
+	umount -l $TARGET2_I18N_DIR
+fi
+if mount | grep -q " on $TARGET2_SYSINFO_FN" ; then
+	umount -l $TARGET2_SYSINFO_FN
+fi
+
 if [ -d $DIR_BACKUP ]; then
 	if [ -f $DIR_BACKUP/fw_stable ]; then
 		sed -i "s/option CHANNEL 'release'/option CHANNEL 'stable'/g" /usr/share/xiaoqiang/xiaoqiang_version
@@ -41,6 +56,7 @@ rm -f $DIR_PATCH/base.*.lmo
 rm -f $INST_FLAG_FN
 rm -f $SYNCOBJECT1
 rm -f $SYNCOBJECT2
+rm -rf $DATA_LANG_ROOT
 
 luci-reload
 rm -f /tmp/luci-indexcache

--- a/install_lang.py
+++ b/install_lang.py
@@ -221,6 +221,8 @@ print("All files uploaded!")
 print("Run scripts...")
 run_script = fn_remote_i if action == 'install' else fn_remote_u
 gw.run_cmd(f"chmod +x {run_script} ; {run_script}", timeout = 17)
+if gw.errcode != 0:
+  die(f'Cannot execute script "{run_script}" (exit code: {gw.errcode})')
 
 time.sleep(1.5)
 
@@ -229,4 +231,21 @@ if full_install:
     gw.run_cmd(f"rm -f {fn_www_remote}")
 
 prefix = '' if action == 'install' else 'un'
+if action == 'install':
+  patch_log = 'tmp/lang_patch.log'
+  if os.path.exists(patch_log):
+    os.remove(patch_log)
+  try:
+    gw.download('/tmp/lang_patch.log', patch_log, verbose = 0)
+  except ssh2.exceptions.SCPProtocolError:
+    die('Language install failed: cannot read /tmp/lang_patch.log')
+  txt = ''
+  if os.path.exists(patch_log):
+    with open(patch_log, 'r', encoding = 'utf-8', errors = 'ignore') as file:
+      txt = file.read().strip()
+  if 'lang patched' not in txt:
+    if not txt:
+      txt = '<empty log>'
+    die(f'Language install failed: {txt}')
+
 print(f"Ready! The language files are {prefix}installed.")


### PR DESCRIPTION
Summary
This PR fixes EN/RU language pack installation on Xiaomi BE3600 (China, RD15), where the patcher previously reported success but the Web UI stayed Chinese after reboot.

Problem
On some newer Xiaomi firmware builds, writing language assets directly under LuCI paths is non-persistent or effectively read-only for this use case.
As a result:
- installer often looked successful,
- language files were not reliably applied after reboot,
- language menu unlock patch could be lost,
- install_lang.py still printed success even when patching failed.

Root cause
The old flow depended on runtime mirrors under tmp and did not strictly validate final patch state before reporting success.

What changed
1. Persistent language storage moved to data
- Language files are now copied to:
  /data/lang/usr/lib/lua/luci/i18n
- sysinfo.htm (with language menu unlock patch) is stored persistently in:
  /data/lang/usr/lib/lua/luci/view/web/inc

2. Runtime bind mounts switched to persistent source
- Bind mount persistent i18n folder to LuCI i18n target.
- Bind mount persistent patched sysinfo.htm file to LuCI sysinfo.htm target.
- This makes language assets and menu patch survive reboot.

3. Boot-race protection added
- lang_patch.sh now waits for data mount readiness before applying bind mounts.

4. Better error handling and status reporting
- Shell scripts now exit with non-zero on real failures and write explicit error text to /tmp/lang_patch.log.
- install_lang.py now:
  - checks remote script exit code,
  - validates /tmp/lang_patch.log contains success marker,
  - stops with a clear error message instead of printing false success.

5. Uninstall flow updated
- Properly unmounts new bind mounts.
- Cleans persistent language storage under data.

Compatibility
- Keeps existing auto apply integration via firewall include script.
- Improves behavior on devices where LuCI paths are not safely writable/persistent.

Why this is important
Users should no longer see a false successful installation when language patch did not apply.
On BE3600 RD15, EN/RU language pack now persists across reboot using the same persistence principle as permanent SSH patches.

Manual verification performed
- Static validation of modified scripts and installer logic.
- Error paths now surface meaningful failures.
- No syntax errors reported by editor diagnostics for changed files.

Suggested reviewer checks on hardware
- Install EN/RU language pack on BE3600 RD15.
- Reboot device.
- Confirm:
  - Web UI language remains EN/RU,
  - language selector is visible,
  - /tmp/lang_patch.log contains success marker,
  - bind mounts target persistent data paths.